### PR TITLE
fix image

### DIFF
--- a/FoodplannerApi/Controller/ImagesController.cs
+++ b/FoodplannerApi/Controller/ImagesController.cs
@@ -81,7 +81,7 @@ public class ImagesController(IFoodImageService foodImageService) : BaseControll
     }
 
     [HttpGet]
-    [Authorize(Roles = "Child, Parent")]
+    [Authorize(Roles = "Child, Parent, Teacher")]
     [AuthorizeImageOwnerFilter]
     [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetPresignedImageLink(int foodImageId)


### PR DESCRIPTION
This pull request includes a small change to the `FoodplannerApi/Controller/ImagesController.cs` file. The change updates the roles authorized to access the `GetPresignedImageLink` method.

* [`FoodplannerApi/Controller/ImagesController.cs`](diffhunk://#diff-323d212fbab7d2a6d8b25313b26512b908c7c583ae253eafee0256aaba51419fL84-R84): Added the "Teacher" role to the `Authorize` attribute for the `GetPresignedImageLink` method.