### PR TITLE
Create user takes string and resolve as string

### DIFF
--- a/FoodplannerModels/Account/UserCreateDTO.cs
+++ b/FoodplannerModels/Account/UserCreateDTO.cs
@@ -27,6 +27,6 @@ namespace FoodplannerModels.Account
         public required string Password { get; set; }
 
         [Required(ErrorMessage = "Role er påkrævet")]
-        public required UserRole Role { get; set; }
+        public required string Role { get; set; }
     }
 }

--- a/Test/AccountTests/Controller/UsersControllerTest.cs
+++ b/Test/AccountTests/Controller/UsersControllerTest.cs
@@ -42,7 +42,7 @@ public class UsersControllerTests
             LastName = "test",
             Email = "user@test.com",
             Password = "test",
-            Role = UserRole.Teacher,
+            Role = "Teacher",
         };
 
         mockUserService
@@ -73,7 +73,7 @@ public class UsersControllerTests
             LastName = "test",
             Email = "user@test.com",
             Password = "test",
-            Role = UserRole.Teacher,
+            Role = "Teacher",
         };
 
         mockUserService
@@ -102,7 +102,7 @@ public class UsersControllerTests
             LastName = "User",
             Email = "test@example.com",
             Password = "password123",
-            Role = UserRole.Parent,
+            Role = "Parent",
         };
 
         mockUserService

--- a/Test/AccountTests/Service/UserServiceTests.cs
+++ b/Test/AccountTests/Service/UserServiceTests.cs
@@ -88,7 +88,7 @@ public class UserServiceTests
         // Arrange
         var expectedId = 1;
         var mail = "nielsen@example.com";
-        var newUser = new UserCreateDTO { FirstName = "niels", LastName = "nielsen", Email = mail, Password = "password", Role =UserRole.Teacher };
+        var newUser = new UserCreateDTO { FirstName = "niels", LastName = "nielsen", Email = mail, Password = "password", Role ="Teacher" };
         var mappedUser = new User { Id = expectedId, FirstName = "niels", LastName = "nielsen", Email = mail, Password = "password", Role =UserRole.Teacher, RoleApproved = true };
         
         _mockMapper
@@ -114,7 +114,7 @@ public class UserServiceTests
         // Arrange
         var expectedId = 1;
         var mail = "nielsen@example.com";
-        var newUser = new UserCreateDTO { FirstName = "niels", LastName = "nielsen", Email = mail, Password = "password", Role =UserRole.Teacher };
+        var newUser = new UserCreateDTO { FirstName = "niels", LastName = "nielsen", Email = mail, Password = "password", Role ="Teacher" };
         var mappedUser = new User { Id = expectedId, FirstName = "niels", LastName = "nielsen", Email = mail, Password = "password", Role =UserRole.Teacher, RoleApproved = true };
         
         _mockMapper


### PR DESCRIPTION
# Description
Create user roles is inputted as strings and manually handled as enums on the back end
