### PR TITLE
Fixed policies for multiple roles

### DIFF
--- a/FoodplannerServices/Auth/AuthService.cs
+++ b/FoodplannerServices/Auth/AuthService.cs
@@ -24,10 +24,17 @@ namespace FoodplannerServices.Auth
         {
             var claims = new List<Claim> {
                 new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
-                new Claim(ClaimTypes.Role, user.Role.ToString()),
                 new Claim("RoleApproved", user.RoleApproved.ToString()),
                 new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
             };
+
+            foreach (UserRole role in Enum.GetValues(typeof(UserRole)))
+            {
+                if (user.Role.HasFlag(role))
+                {
+                    claims.Add(new Claim(ClaimTypes.Role, role.ToString()));
+                }
+            }
 
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_secretsLoader.GetSecret("JWT_SECRET")));
             var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);


### PR DESCRIPTION
# Description
Found out when having multiple roles it messes with the policies because it used the "Whole" string which is wrong, it should be handled case by case so now it iterates through roles and add it to claims individually.
