### PR TITLE
Hotfix: Add necessary parameter to PostgreSQL container

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -28,6 +28,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_DB=giraf
+      - PGDATA=/var/lib/postgresql/data/pgdata
 
   adminer:
     image: adminer


### PR DESCRIPTION
We should probably pin the docker images, so they don't break in the future