### PR TITLE
chore: add minio/ and postgres/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ FoodplannerApi/appsettings.Development.json
 /.vs
 *.env
 docker-compose.yml
+
+# Local development data
+minio/
+postgres/


### PR DESCRIPTION
## Summary
- Add `minio/` and `postgres/` to `.gitignore` to prevent local development data from being committed
- Fix missing trailing newline

Closes #224