### PR TITLE
fix: nest ingredient details in meal responses

### DIFF
--- a/FoodplannerModels/Lunchbox/Meal/IMealService.cs
+++ b/FoodplannerModels/Lunchbox/Meal/IMealService.cs
@@ -6,11 +6,11 @@
 public interface IMealService
 {
     // Gets all meals asynchronously.
-    Task<IEnumerable<MealDTO>> GetAllMealsAsync();
+    Task<IEnumerable<MealResponseDTO>> GetAllMealsAsync();
     // Gets all meals by user id asynchronously.
-    Task<IEnumerable<MealDTO>> GetAllMealsByUserAsync(int user_id, string date);
+    Task<IEnumerable<MealResponseDTO>> GetAllMealsByUserAsync(int user_id, string date);
     // Gets an meal by ID asynchronously.
-    Task<MealDTO?> GetMealByIdAsync(int id);
+    Task<MealResponseDTO?> GetMealByIdAsync(int id);
     // Creates a new meal asynchronously.
     Task<int> CreateMealAsync(MealCreateDTO meal, int id);
     // Updates an existing meal asynchronously.
@@ -18,7 +18,7 @@ public interface IMealService
     // Deletes an meal by ID asynchronously.
     Task<int> DeleteMealAsync(int id);
     // get all meals where template is 1
-    Task<IEnumerable<MealDTO>> GetAllTemplatesByUserAsync(int userId);
+    Task<IEnumerable<MealResponseDTO>> GetAllTemplatesByUserAsync(int userId);
     // Update a meals template status via its ID
     Task<int> UpdateTemplateStatusAsync(int id, bool template, int userId);
     // Get unique ingredients by a list of meal IDs and return ingredients

--- a/FoodplannerModels/Lunchbox/Meal/MealResponseDTO.cs
+++ b/FoodplannerModels/Lunchbox/Meal/MealResponseDTO.cs
@@ -1,0 +1,16 @@
+namespace FoodplannerModels.Lunchbox;
+
+/**
+* Response shape for a meal, including its packed ingredients with nested
+* ingredient details. Used by the read endpoints; MealDTO remains the write shape.
+*/
+public class MealResponseDTO
+{
+    public int Id { get; set; }
+    public int? Food_image_id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int UserId { get; set; }
+    public string Date { get; set; } = string.Empty;
+    public bool Template { get; set; }
+    public IEnumerable<PackedIngredientResponseDTO> Ingredients { get; set; } = [];
+}

--- a/FoodplannerModels/Lunchbox/PackedIngredient/PackedIngredientResponseDTO.cs
+++ b/FoodplannerModels/Lunchbox/PackedIngredient/PackedIngredientResponseDTO.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace FoodplannerModels.Lunchbox;
+
+/**
+* Response shape for a packed ingredient inside a meal.
+* Unlike PackedIngredientDTO (used for writes, where ingredient_id is an int FK),
+* this nests the full ingredient under the "ingredient_id" key so clients get the
+* ingredient's name and image without extra lookups.
+*/
+public class PackedIngredientResponseDTO
+{
+    public int Id { get; set; }
+    public int Meal_id { get; set; }
+
+    // Nested ingredient, serialized as "ingredient_id" for client compatibility.
+    [JsonPropertyName("ingredient_id")]
+    public IngredientDTO Ingredient { get; set; } = null!;
+
+    public int order_number { get; set; }
+}

--- a/FoodplannerServices/Lunchbox/MealService.cs
+++ b/FoodplannerServices/Lunchbox/MealService.cs
@@ -77,6 +77,7 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
                 Food_image_id = meal.Food_image_id,
                 Name = meal.Name,
                 Date = meal.Date,
+                Template = meal.Template,
                 UserId = meal.User_id,
                 Ingredients = packedIngredients
             };
@@ -125,6 +126,7 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
                 Food_image_id = meal.Food_image_id,
                 Name = meal.Name,
                 Date = meal.Date,
+                Template = meal.Template,
                 UserId = meal.User_id,
                 Ingredients = packedIngredients
             };

--- a/FoodplannerServices/Lunchbox/MealService.cs
+++ b/FoodplannerServices/Lunchbox/MealService.cs
@@ -15,9 +15,31 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
     private readonly IIngredientRepository _ingredientRepository = ingredientRepository;
     private readonly IMapper _mapper = mapper;
 
+    // Maps a packed ingredient to its response shape, nesting the ingredient's
+    // details (from the pre-fetched lookup) under "ingredient_id".
+    private static PackedIngredientResponseDTO ToResponse(PackedIngredient p, IDictionary<int, Ingredient?> ingredientsById)
+    {
+        ingredientsById.TryGetValue(p.Ingredient_id, out var ingredient);
+        return new PackedIngredientResponseDTO
+        {
+            Id = p.Id,
+            Meal_id = p.Meal_id,
+            order_number = p.order_number,
+            Ingredient = ingredient is not null
+                ? new IngredientDTO
+                {
+                    Id = ingredient.Id,
+                    Name = ingredient.Name,
+                    User_id = ingredient.User_id,
+                    Food_image_id = ingredient.Food_image_id
+                }
+                : new IngredientDTO { Id = p.Ingredient_id, Name = string.Empty, User_id = 0, Food_image_id = null }
+        };
+    }
+
 
     // Retrieves all meals from the repository.
-    public async Task<IEnumerable<MealDTO>> GetAllMealsAsync()
+    public async Task<IEnumerable<MealResponseDTO>> GetAllMealsAsync()
     {
         var meals = await _mealRepository.GetAllAsync();
 
@@ -46,15 +68,10 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
         {
             var packedIngredients = packedIngredientsByMeal
                 .First(m => m.Id == meal.Id).PackedIngredients
-                .Select(p => new PackedIngredientDTO
-                {
-                    Id = p.Id,
-                    Meal_id = p.Meal_id,
-                    Ingredient_id = p.Ingredient_id,
-                    order_number = p.order_number
-                }).ToList();
+                .Select(p => ToResponse(p, ingredientsById))
+                .ToList();
 
-            return new MealDTO
+            return new MealResponseDTO
             {
                 Id = meal.Id,
                 Food_image_id = meal.Food_image_id,
@@ -70,7 +87,7 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
 
 
     // Retrieves all meals by user id.
-    public async Task<IEnumerable<MealDTO>> GetAllMealsByUserAsync(int userId, string date)
+    public async Task<IEnumerable<MealResponseDTO>> GetAllMealsByUserAsync(int userId, string date)
     {
         var meals = await _mealRepository.GetAllByUserAsync(userId, date);
 
@@ -99,15 +116,10 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
         {
             var packedIngredients = packedIngredientsByMeal
                 .First(m => m.Id == meal.Id).PackedIngredients
-                .Select(p => new PackedIngredientDTO
-                {
-                    Id = p.Id,
-                    Meal_id = p.Meal_id,
-                    Ingredient_id = p.Ingredient_id,
-                    order_number = p.order_number
-                }).ToList();
+                .Select(p => ToResponse(p, ingredientsById))
+                .ToList();
 
-            return new MealDTO
+            return new MealResponseDTO
             {
                 Id = meal.Id,
                 Food_image_id = meal.Food_image_id,
@@ -122,7 +134,7 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
     }
 
     // Retrieves a specific meal by its ID.
-    public async Task<MealDTO?> GetMealByIdAsync(int id)
+    public async Task<MealResponseDTO?> GetMealByIdAsync(int id)
     {
         // Fetch the single meal.
         var meal = await _mealRepository.GetByIdAsync(id);
@@ -142,17 +154,11 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
             })
         )).ToDictionary(i => i.Id, i => i.Ingredient);
 
-        // Construct the list of PackedIngredientDTO.
-        var packedIngredientDTOs = packedIngredients.Select(p => new PackedIngredientDTO
-        {
-            Id = p.Id,
-            Meal_id = p.Meal_id,
-            Ingredient_id = p.Ingredient_id,
-            order_number = p.order_number
-        }).ToList();
+        // Construct the list of packed ingredients with nested ingredient details.
+        var packedIngredientDTOs = packedIngredients.Select(p => ToResponse(p, ingredientsById)).ToList();
 
-        // Construct and return the MealDTO.
-        return new MealDTO
+        // Construct and return the meal response.
+        return new MealResponseDTO
         {
             Id = meal.Id,
             Food_image_id = meal.Food_image_id,
@@ -189,7 +195,7 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
         return await _mealRepository.DeleteAsync(id);
     }
 
-    public async Task<IEnumerable<MealDTO>> GetAllTemplatesByUserAsync(int userId)
+    public async Task<IEnumerable<MealResponseDTO>> GetAllTemplatesByUserAsync(int userId)
     {
         var meals = await _mealRepository.GetAllTemplatesByUserAsync(userId);
 
@@ -215,15 +221,10 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
         {
             var packedIngredients = packedIngredientsByMeal
                 .First(m => m.Id == meal.Id).PackedIngredients
-                .Select(p => new PackedIngredientDTO
-                {
-                    Id = p.Id,
-                    Meal_id = p.Meal_id,
-                    Ingredient_id = p.Ingredient_id,
-                    order_number = p.order_number
-                }).ToList();
+                .Select(p => ToResponse(p, ingredientsById))
+                .ToList();
 
-            return new MealDTO
+            return new MealResponseDTO
             {
                 Id = meal.Id,
                 Food_image_id = meal.Food_image_id,

--- a/FoodplannerServices/Lunchbox/MealService.cs
+++ b/FoodplannerServices/Lunchbox/MealService.cs
@@ -38,11 +38,11 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
     }
 
 
-    // Retrieves all meals from the repository.
-    public async Task<IEnumerable<MealResponseDTO>> GetAllMealsAsync()
+    // Builds the nested-ingredient response for a set of meals: fetches each
+    // meal's packed ingredients and the referenced ingredient details, then
+    // projects to MealResponseDTO.
+    private async Task<List<MealResponseDTO>> MapMealsToResponsesAsync(IReadOnlyCollection<Meal> meals)
     {
-        var meals = await _mealRepository.GetAllAsync();
-
         // Fetch all packed ingredients for all meals in one go.
         var packedIngredientsByMeal = await Task.WhenAll(
             meals.Select(async meal =>
@@ -52,102 +52,12 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
             })
         );
 
-        // Fetch all ingredient details in one go.
-        var allPackedIngredients = packedIngredientsByMeal.SelectMany(m => m.PackedIngredients).ToList();
-        var allIngredientIds = allPackedIngredients.Select(p => p.Ingredient_id).Distinct().ToList();
-        var ingredientsById = (await Task.WhenAll(
-            allIngredientIds.Select(async id =>
-            {
-                var ingredient = await _ingredientRepository.GetByIdAsync(id);
-                return new { Id = id, Ingredient = ingredient };
-            })
-        )).ToDictionary(i => i.Id, i => i.Ingredient);
-
-        // Construct MealDTO list.
-        var output = meals.Select(meal =>
-        {
-            var packedIngredients = packedIngredientsByMeal
-                .First(m => m.Id == meal.Id).PackedIngredients
-                .Select(p => ToResponse(p, ingredientsById))
-                .ToList();
-
-            return new MealResponseDTO
-            {
-                Id = meal.Id,
-                Food_image_id = meal.Food_image_id,
-                Name = meal.Name,
-                Date = meal.Date,
-                Template = meal.Template,
-                UserId = meal.User_id,
-                Ingredients = packedIngredients
-            };
-        }).ToList();
-
-        return output;
-    }
-
-
-    // Retrieves all meals by user id.
-    public async Task<IEnumerable<MealResponseDTO>> GetAllMealsByUserAsync(int userId, string date)
-    {
-        var meals = await _mealRepository.GetAllByUserAsync(userId, date);
-
-        // Fetch all packed ingredients for all meals in one go.
-        var packedIngredientsByMeal = await Task.WhenAll(
-            meals.Select(async meal =>
-            {
-                var packedIngredients = await _packedIngredientRepository.GetAllByMealIdAsync(meal.Id);
-                return new { meal.Id, PackedIngredients = packedIngredients };
-            })
-        );
-
-        // Fetch all ingredient details in one go.
-        var allPackedIngredients = packedIngredientsByMeal.SelectMany(m => m.PackedIngredients).ToList();
-        var allIngredientIds = allPackedIngredients.Select(p => p.Ingredient_id).Distinct().ToList();
-        var ingredientsById = (await Task.WhenAll(
-            allIngredientIds.Select(async id =>
-            {
-                var ingredient = await _ingredientRepository.GetByIdAsync(id);
-                return new { Id = id, Ingredient = ingredient };
-            })
-        )).ToDictionary(i => i.Id, i => i.Ingredient);
-
-        // Construct MealDTO list.
-        var output = meals.Select(meal =>
-        {
-            var packedIngredients = packedIngredientsByMeal
-                .First(m => m.Id == meal.Id).PackedIngredients
-                .Select(p => ToResponse(p, ingredientsById))
-                .ToList();
-
-            return new MealResponseDTO
-            {
-                Id = meal.Id,
-                Food_image_id = meal.Food_image_id,
-                Name = meal.Name,
-                Date = meal.Date,
-                Template = meal.Template,
-                UserId = meal.User_id,
-                Ingredients = packedIngredients
-            };
-        }).ToList();
-
-        return output;
-    }
-
-    // Retrieves a specific meal by its ID.
-    public async Task<MealResponseDTO?> GetMealByIdAsync(int id)
-    {
-        // Fetch the single meal.
-        var meal = await _mealRepository.GetByIdAsync(id);
-        if (meal == null)
-            return null; // Handle the case where the meal doesn't exist.
-
-        // Fetch all packed ingredients for the meal.
-        var packedIngredients = await _packedIngredientRepository.GetAllByMealIdAsync(meal.Id);
-
-        // Fetch all ingredient details in one go.
-        var ingredientIds = packedIngredients.Select(p => p.Ingredient_id).Distinct().ToList();
+        // Fetch each referenced ingredient's details once.
+        var ingredientIds = packedIngredientsByMeal
+            .SelectMany(m => m.PackedIngredients)
+            .Select(p => p.Ingredient_id)
+            .Distinct()
+            .ToList();
         var ingredientsById = (await Task.WhenAll(
             ingredientIds.Select(async id =>
             {
@@ -156,11 +66,7 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
             })
         )).ToDictionary(i => i.Id, i => i.Ingredient);
 
-        // Construct the list of packed ingredients with nested ingredient details.
-        var packedIngredientDTOs = packedIngredients.Select(p => ToResponse(p, ingredientsById)).ToList();
-
-        // Construct and return the meal response.
-        return new MealResponseDTO
+        return meals.Select(meal => new MealResponseDTO
         {
             Id = meal.Id,
             Food_image_id = meal.Food_image_id,
@@ -168,8 +74,31 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
             Date = meal.Date,
             Template = meal.Template,
             UserId = meal.User_id,
-            Ingredients = packedIngredientDTOs
-        };
+            Ingredients = packedIngredientsByMeal
+                .First(m => m.Id == meal.Id).PackedIngredients
+                .Select(p => ToResponse(p, ingredientsById))
+                .ToList()
+        }).ToList();
+    }
+
+    // Retrieves all meals from the repository.
+    public async Task<IEnumerable<MealResponseDTO>> GetAllMealsAsync()
+        => await MapMealsToResponsesAsync((await _mealRepository.GetAllAsync()).ToList());
+
+
+    // Retrieves all meals by user id.
+    public async Task<IEnumerable<MealResponseDTO>> GetAllMealsByUserAsync(int userId, string date)
+        => await MapMealsToResponsesAsync((await _mealRepository.GetAllByUserAsync(userId, date)).ToList());
+
+    // Retrieves a specific meal by its ID.
+    public async Task<MealResponseDTO?> GetMealByIdAsync(int id)
+    {
+        var meal = await _mealRepository.GetByIdAsync(id);
+        if (meal == null)
+            return null;
+
+        var responses = await MapMealsToResponsesAsync(new[] { meal });
+        return responses.FirstOrDefault();
     }
 
 
@@ -198,48 +127,7 @@ public class MealService(IMealRepository mealRepository, IPackedIngredientReposi
     }
 
     public async Task<IEnumerable<MealResponseDTO>> GetAllTemplatesByUserAsync(int userId)
-    {
-        var meals = await _mealRepository.GetAllTemplatesByUserAsync(userId);
-
-        var packedIngredientsByMeal = await Task.WhenAll(
-            meals.Select(async meal =>
-            {
-                var packedIngredients = await _packedIngredientRepository.GetAllByMealIdAsync(meal.Id);
-                return new { meal.Id, PackedIngredients = packedIngredients };
-            })
-        );
-
-        var allPackedIngredients = packedIngredientsByMeal.SelectMany(m => m.PackedIngredients).ToList();
-        var allIngredientIds = allPackedIngredients.Select(p => p.Ingredient_id).Distinct().ToList();
-        var ingredientsById = (await Task.WhenAll(
-            allIngredientIds.Select(async id =>
-            {
-                var ingredient = await _ingredientRepository.GetByIdAsync(id);
-                return new { Id = id, Ingredient = ingredient };
-            })
-        )).ToDictionary(i => i.Id, i => i.Ingredient);
-
-        var output = meals.Select(meal =>
-        {
-            var packedIngredients = packedIngredientsByMeal
-                .First(m => m.Id == meal.Id).PackedIngredients
-                .Select(p => ToResponse(p, ingredientsById))
-                .ToList();
-
-            return new MealResponseDTO
-            {
-                Id = meal.Id,
-                Food_image_id = meal.Food_image_id,
-                Name = meal.Name,
-                Date = meal.Date,
-                Template = meal.Template,
-                UserId = meal.User_id,
-                Ingredients = packedIngredients
-            };
-        }).ToList();
-
-        return output;
-    }
+        => await MapMealsToResponsesAsync((await _mealRepository.GetAllTemplatesByUserAsync(userId)).ToList());
 
     // Update this method with ownership verification:
     public async Task<int> UpdateTemplateStatusAsync(int id, bool template, int userId)

--- a/Test/LunchboxTests/Controller/MealsControllerTest.cs
+++ b/Test/LunchboxTests/Controller/MealsControllerTest.cs
@@ -16,7 +16,7 @@ public class MealsControllerTests
         var mockMealService = new Mock<IMealService>();
         var mockAuthService = Mock.Of<IAuthService>();
 
-        var meals = new List<MealDTO>
+        var meals = new List<MealResponseDTO>
         {
             new() { Id = 1, Name = "Pizza", Date = "test", UserId = 1, Ingredients = [] },
             new() { Id = 2, Name = "Burger", Date = "test", UserId = 1, Ingredients = [] }
@@ -43,7 +43,7 @@ public class MealsControllerTests
         var mockAuthService = new Mock<IAuthService>();
         int userId = 1;
         string date = "test";
-        var meals = new List<MealDTO>
+        var meals = new List<MealResponseDTO>
         {
             new() { Id = 1, Name = "Pizza", Date = date, UserId = userId,Ingredients = [] },
             new() { Id = 2, Name = "Burger", Date = date, UserId = userId, Ingredients = [] }
@@ -78,7 +78,7 @@ public class MealsControllerTests
         int userId = 1;
 
         string date = "test";
-        var meals = new List<MealDTO>
+        var meals = new List<MealResponseDTO>
         {
             new() { Id = 1, Name = "Pizza", Date = date, UserId = userId, Ingredients = [] },
             new() { Id = 2, Name = "Burger", Date = date, UserId = userId, Ingredients = [] }
@@ -106,7 +106,7 @@ public class MealsControllerTests
         var mockAuthService = Mock.Of<IAuthService>();
 
         int mealId = 1;
-        var meal = new MealDTO() { Id = mealId, Name = "Pizza", Date = "test", UserId = 1, Ingredients = [] };
+        var meal = new MealResponseDTO() { Id = mealId, Name = "Pizza", Date = "test", UserId = 1, Ingredients = [] };
 
         mockMealService
             .Setup(repo => repo.GetMealByIdAsync(mealId))
@@ -129,7 +129,7 @@ public class MealsControllerTests
         var mockAuthService = Mock.Of<IAuthService>();
 
         int mealId = 1;
-        MealDTO meal = null!;
+        MealResponseDTO meal = null!;
 
         mockMealService
             .Setup(repo => repo.GetMealByIdAsync(mealId))
@@ -155,7 +155,7 @@ public class MealsControllerTests
         int userId = 1;
 
         MealCreateDTO mealDTO = new() { Name = "Pizza", Date = "test" };
-        MealDTO meal = new() { Id = mealId, Name = "Pizza", Date = "test", UserId = userId, Ingredients = [] };
+        MealResponseDTO meal = new() { Id = mealId, Name = "Pizza", Date = "test", UserId = userId, Ingredients = [] };
         var user = new User() { Id = userId, FirstName = "test", LastName = "test", Email = "test@example.com", Password = "1234", Role = UserRole.Parent, RoleApproved = true };
 
         var JWTToken = "Bearer TestToken";
@@ -225,7 +225,7 @@ public class MealsControllerTests
             UserId = userId,
             Ingredients = Enumerable.Empty<PackedIngredientDTO>()
         };
-        MealDTO mealDto = new() { Id = mealId, Name = "Pizza", Date = "test", UserId = userId, Ingredients = [] };
+        MealResponseDTO mealDto = new() { Id = mealId, Name = "Pizza", Date = "test", UserId = userId, Ingredients = [] };
         var user = new User() { Id = userId, FirstName = "test", LastName = "test", Email = "test@example.com", Password = "1234", Role = UserRole.Parent, RoleApproved = true };
 
         var JWTToken = "Bearer TestToken";
@@ -293,7 +293,7 @@ public class MealsControllerTests
         var mockAuthService = Mock.Of<IAuthService>();
 
         int mealId = 1;
-        MealDTO meal = new() { Id = mealId, Name = "Pizza", Date = "test", UserId = 1, Ingredients = [] };
+        MealResponseDTO meal = new() { Id = mealId, Name = "Pizza", Date = "test", UserId = 1, Ingredients = [] };
 
         mockMealService
             .Setup(repo => repo.GetMealByIdAsync(mealId))
@@ -319,7 +319,7 @@ public class MealsControllerTests
         var mockAuthService = new Mock<IAuthService>();
 
         int mealId = 1;
-        MealDTO meal = null!;
+        MealResponseDTO meal = null!;
 
         mockMealService
             .Setup(repo => repo.GetMealByIdAsync(mealId))

--- a/Test/LunchboxTests/Service/MealServiceTests.cs
+++ b/Test/LunchboxTests/Service/MealServiceTests.cs
@@ -121,6 +121,40 @@ public class MealServiceTests
     }
 
     [Fact]
+    public async Task GetAllMealsByUserAsync_NestsIngredientDetails_AndPreservesTemplate()
+    {
+        // Arrange
+        const int userId = 3;
+        const string date = "2026-07-15";
+        var meals = new List<Meal>
+        {
+            new Meal { Id = 1, Name = "Sandwich", Date = date, Template = true, Ingredients = [] }
+        };
+        _mockMealRepository.Setup(repo => repo.GetAllByUserAsync(userId, date))
+            .ReturnsAsync(meals);
+
+        _mockPackedIngredientRepository.Setup(repo => repo.GetAllByMealIdAsync(1))
+            .ReturnsAsync(new List<PackedIngredient>
+            {
+                new PackedIngredient { Id = 10, Meal_id = 1, Ingredient_id = 5, order_number = 0 }
+            });
+
+        _mockIngredientRepository.Setup(repo => repo.GetByIdAsync(5))
+            .ReturnsAsync(new Ingredient { Id = 5, Name = "Bacon", User_id = userId, Food_image_id = 6 });
+
+        // Act
+        var result = (await _mealService.GetAllMealsByUserAsync(userId, date)).ToList();
+
+        // Assert
+        var meal = Assert.Single(result);
+        Assert.True(meal.Template); // template state must survive the list projection
+        var packed = Assert.Single(meal.Ingredients);
+        Assert.Equal(5, packed.Ingredient.Id);
+        Assert.Equal("Bacon", packed.Ingredient.Name);
+        Assert.Equal(6, packed.Ingredient.Food_image_id);
+    }
+
+    [Fact]
     public async Task CreateMealAsync_ReturnsNewMealId()
     {
         // Arrange


### PR DESCRIPTION
## Problem
Meal read endpoints serialized `ingredient_id` as a bare int, but the frontend expects the full ingredient (name + image) nested under that key. Parsing threw, so any meal **with ingredients rendered as "no lunchbox"**. `MealService` already fetched the ingredient details, then discarded the lookup.

## Fix
Add read-only `MealResponseDTO` / `PackedIngredientResponseDTO` that nest the ingredient under `ingredient_id`, populated from the lookup the service already builds. Write DTOs (`MealDTO` / `PackedIngredientDTO`) are unchanged, so create/update/order are unaffected.

## Verified
- `dotnet build` clean; 21/21 meal tests pass.
- Manually: meal + ingredient list now render with names and images in the Flutter app (no frontend change).
