### PR TITLE
Add real-time messaging to FeedbackChat via SignalR (#230)

### DIFF
--- a/FoodplannerApi/Program.cs
+++ b/FoodplannerApi/Program.cs
@@ -27,6 +27,7 @@ using FoodplannerModels.Image;
 using FoodplannerModels.Codes;
 using FoodplannerDataAccessSql.Codes;
 using FoodplannerServices.Codes;
+using FoodplannerServices.Hubs;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -155,6 +156,18 @@ builder.Services.AddAuthentication(cfg =>
     };
     x.Events = new JwtBearerEvents
     {
+        OnMessageReceived = context =>
+        {
+            var accessToken = context.Request.Query["access_token"];
+
+            if (!string.IsNullOrEmpty(accessToken) &&
+                context.HttpContext.Request.Path.StartsWithSegments("/hubs/chat"))
+            {
+                context.Token = accessToken;
+            }
+
+            return Task.CompletedTask;
+        },
         OnTokenValidated = context =>
         {
             var principal = context.Principal;
@@ -218,6 +231,7 @@ builder.Services.AddScoped<IMealService, MealService>();
 builder.Services.AddScoped<IPackedIngredientService, PackedIngredientService>();
 builder.Services.AddScoped<IOneTimePasswordService, OneTimePasswordService>();
 builder.Services.AddSingleton<ISecretLoader, SecretsLoader>(_ => secretsLoader);
+builder.Services.AddSignalR();
 
 builder.Services.AddAutoMapper(typeof(UserProfile), typeof(PackedIngredientProfile));
 builder.Services.AddAutoMapper(typeof(SubIngredientProfile));
@@ -286,6 +300,7 @@ app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
+app.MapHub<ChatHub>("/hubs/chat");
 
 // New endpoint to test database connection
 app.MapGet("/test-db-connection", async (PostgreSQLConnectionFactory connectionFactory) =>

--- a/FoodplannerDataAccessSql/FeedbackChat/ChatRepository.cs
+++ b/FoodplannerDataAccessSql/FeedbackChat/ChatRepository.cs
@@ -108,12 +108,13 @@ public class ChatRepository(PostgreSQLConnectionFactory connectionFactory) : ICh
 
     public async Task<int> InsertAsync(Message message)
     {
-        const string sql = "INSERT INTO message (content, date, chat_thread_id, user_id) VALUES (@Content, @Date, @ChatThreadId, @UserId)";
+        const string sql = "INSERT INTO message (content, date, chat_thread_id, user_id) VALUES (@Content, @Date, @ChatThreadId, @UserId) RETURNING message_id";
         await using (var connection = connectionFactory.Create())
         {
             connection.Open();
-            var result = await connection.ExecuteAsync(sql, message);
-            return result;
+            var messageId = await connection.ExecuteScalarAsync<int>(sql, message);
+            message.MessageId = messageId;
+            return messageId;
         }
     }
 

--- a/FoodplannerModels/FeedbackChat/IChatRepository.cs
+++ b/FoodplannerModels/FeedbackChat/IChatRepository.cs
@@ -4,9 +4,10 @@ using FoodplannerModels.FeedbackChat;
 public interface IChatRepository : IGenericRepository<Message>
 {
     // Methods for ChatThread
+    Task<ChatThread> GetChatThreadByIdAsync(int chatThreadId);
     Task<int> GetChatThreadIdByChildIdAsync(int ChildId);
     Task<int> AddChatThreadIdByChildIdAsync(int ChildId);
-    
+
 
     // Methods for Message
     Task<IEnumerable<Message>> GetMessagesByChatThreadIdAsync(int chatThreadId);

--- a/FoodplannerModels/FeedbackChat/UserNameFeedbackChatDTO.cs
+++ b/FoodplannerModels/FeedbackChat/UserNameFeedbackChatDTO.cs
@@ -2,6 +2,8 @@
 
 public class UserNameFeedbackChatDTO
 {
+    public int MessageId { get; set; }
+    public int ChatThreadId { get; set; }
     public required string Content { get; set; }
     public required string FirstName { get; set; }
     public DateTime Date { get; set; }

--- a/FoodplannerServices/FeedbackChat/ChatService.cs
+++ b/FoodplannerServices/FeedbackChat/ChatService.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
 using FoodplannerModels.Account;
+using FoodplannerServices.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
 
 
 namespace FoodplannerServices.FeedbackChat
@@ -12,12 +15,18 @@ namespace FoodplannerServices.FeedbackChat
         private readonly IChatRepository _chatRepository;
         private readonly IMapper _mapper;
         private readonly IChildrenRepository _childrenRepository;
+        private readonly IUserRepository _userRepository;
+        private readonly IHubContext<ChatHub> _hubContext;
+        private readonly ILogger<ChatService> _logger;
 
-        public ChatService(IChatRepository chatRepository, IMapper mapper, IChildrenRepository childrenRepository)
+        public ChatService(IChatRepository chatRepository, IMapper mapper, IChildrenRepository childrenRepository, IUserRepository userRepository, IHubContext<ChatHub> hubContext, ILogger<ChatService> logger)
         {
             _childrenRepository = childrenRepository;
             _chatRepository = chatRepository;
             _mapper = mapper;
+            _userRepository = userRepository;
+            _hubContext = hubContext;
+            _logger = logger;
         }
 
         // Methods for ChatThread
@@ -26,8 +35,26 @@ namespace FoodplannerServices.FeedbackChat
             var message = _mapper.Map<Message>(messageDTO);
             message.Date = System.DateTime.Now;
             message.UserId = userId;
-            
+
             await _chatRepository.InsertAsync(message);
+
+            try
+            {
+                var messageDto = _mapper.Map<UserNameFeedbackChatDTO>(message);
+
+                var user = await _userRepository.GetByIdAsync(userId);
+                if (user != null)
+                {
+                    messageDto.FirstName = user.FirstName;
+                }
+
+                await _hubContext.Clients.Group($"thread-{message.ChatThreadId}").SendAsync("ReceiveMessage", messageDto);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Failed to broadcast new FeedbackChat message to group thread-{message.ChatThreadId}");
+            }
+
             return true;
         }
 

--- a/FoodplannerServices/FoodplannerServices.csproj
+++ b/FoodplannerServices/FoodplannerServices.csproj
@@ -13,6 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Minio" Version="6.0.3" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />

--- a/FoodplannerServices/Hubs/ChatHub.cs
+++ b/FoodplannerServices/Hubs/ChatHub.cs
@@ -1,3 +1,6 @@
+using System.Security.Claims;
+using FoodplannerModels.Account;
+using FoodplannerModels.FeedbackChat;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
@@ -6,13 +9,52 @@ namespace FoodplannerServices.Hubs;
 [Authorize(Roles = "Parent, Teacher")]
 public class ChatHub : Hub
 {
+    private readonly IChatRepository _chatRepository;
+    private readonly IChildrenRepository _childrenRepository;
+
+    public ChatHub(IChatRepository chatRepository, IChildrenRepository childrenRepository)
+    {
+        _chatRepository = chatRepository;
+        _childrenRepository = childrenRepository;
+    }
+
     public async Task JoinThread(int chatThreadId)
     {
+        await EnsureCallerIsAuthorizedForThreadAsync(chatThreadId);
         await Groups.AddToGroupAsync(Context.ConnectionId, $"thread-{chatThreadId}");
     }
 
     public async Task LeaveThread(int chatThreadId)
     {
+        await EnsureCallerIsAuthorizedForThreadAsync(chatThreadId);
         await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"thread-{chatThreadId}");
+    }
+
+    private async Task EnsureCallerIsAuthorizedForThreadAsync(int chatThreadId)
+    {
+        var chatThread = await _chatRepository.GetChatThreadByIdAsync(chatThreadId);
+
+        var userIdClaim = Context.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!int.TryParse(userIdClaim, out var userId))
+        {
+            throw new HubException("Not authorized for this chat thread");
+        }
+
+        var isAuthorized = false;
+        if (Context.User != null && Context.User.IsInRole("Parent"))
+        {
+            var parents = await _childrenRepository.GetParentsByChildIdAsync(chatThread.ChildId);
+            isAuthorized = parents.Any(parent => parent.Id == userId);
+        }
+        else if (Context.User != null && Context.User.IsInRole("Teacher"))
+        {
+            var teachers = await _childrenRepository.GetTeachersByChildIdAsync(chatThread.ChildId);
+            isAuthorized = teachers.Any(teacher => teacher.Id == userId);
+        }
+
+        if (!isAuthorized)
+        {
+            throw new HubException("Not authorized for this chat thread");
+        }
     }
 }

--- a/FoodplannerServices/Hubs/ChatHub.cs
+++ b/FoodplannerServices/Hubs/ChatHub.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace FoodplannerServices.Hubs;
+
+[Authorize(Roles = "Parent, Teacher")]
+public class ChatHub : Hub
+{
+    public async Task JoinThread(int chatThreadId)
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"thread-{chatThreadId}");
+    }
+
+    public async Task LeaveThread(int chatThreadId)
+    {
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"thread-{chatThreadId}");
+    }
+}

--- a/Test/FeedbackChatTests/ChatProfileTests.cs
+++ b/Test/FeedbackChatTests/ChatProfileTests.cs
@@ -1,0 +1,37 @@
+using AutoMapper;
+using FoodplannerModels.FeedbackChat;
+
+namespace Test.Service;
+
+public class ChatProfileTests
+{
+    private readonly IMapper _mapper;
+
+    public ChatProfileTests()
+    {
+        var configuration = new MapperConfiguration(cfg => cfg.AddProfile<ChatProfile>());
+        _mapper = configuration.CreateMapper();
+    }
+
+    [Fact]
+    public void Map_MessageToUserNameFeedbackChatDTO_MapsMessageIdAndChatThreadIdByConvention()
+    {
+        // Arrange
+        var message = new Message
+        {
+            MessageId = 123,
+            ChatThreadId = 42,
+            Content = "Hello",
+            UserId = 7,
+            Date = DateTime.UtcNow
+        };
+
+        // Act
+        var dto = _mapper.Map<UserNameFeedbackChatDTO>(message);
+
+        // Assert — AutoMapper's default convention (matching property names/types) is
+        // expected to pick these up with no explicit .ForMember() configuration.
+        Assert.Equal(123, dto.MessageId);
+        Assert.Equal(42, dto.ChatThreadId);
+    }
+}

--- a/Test/FeedbackChatTests/Hub/ChatHubTests.cs
+++ b/Test/FeedbackChatTests/Hub/ChatHubTests.cs
@@ -1,0 +1,142 @@
+using System.Security.Claims;
+using FoodplannerModels.Account;
+using FoodplannerModels.FeedbackChat;
+using FoodplannerServices.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+
+namespace Test.Service;
+
+public class ChatHubTests
+{
+    private readonly Mock<IChatRepository> _mockChatRepository;
+    private readonly Mock<IChildrenRepository> _mockChildrenRepository;
+    private readonly Mock<HubCallerContext> _mockContext;
+    private readonly Mock<IGroupManager> _mockGroups;
+    private readonly ChatHub _chatHub;
+
+    public ChatHubTests()
+    {
+        _mockChatRepository = new Mock<IChatRepository>();
+        _mockChildrenRepository = new Mock<IChildrenRepository>();
+        _mockContext = new Mock<HubCallerContext>();
+        _mockGroups = new Mock<IGroupManager>();
+
+        _mockContext.Setup(c => c.ConnectionId).Returns("connection-1");
+
+        _chatHub = new ChatHub(_mockChatRepository.Object, _mockChildrenRepository.Object)
+        {
+            Context = _mockContext.Object,
+            Groups = _mockGroups.Object
+        };
+    }
+
+    private void SetCallerIdentity(int userId, string role)
+    {
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+            new Claim(ClaimTypes.Role, role)
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth", ClaimTypes.Name, ClaimTypes.Role);
+        _mockContext.Setup(c => c.User).Returns(new ClaimsPrincipal(identity));
+    }
+
+    private static User MakeUser(int id) => new User
+    {
+        Id = id,
+        FirstName = "Test",
+        LastName = "User",
+        Email = $"user{id}@example.com",
+        Password = "hashed",
+        Role = UserRole.Parent,
+        RoleApproved = true
+    };
+
+    [Fact]
+    public async Task JoinThread_ParentAssociatedWithChild_AddsConnectionToGroup()
+    {
+        // Arrange
+        const int chatThreadId = 5;
+        const int childId = 10;
+        const int userId = 42;
+        SetCallerIdentity(userId, "Parent");
+
+        _mockChatRepository.Setup(repo => repo.GetChatThreadByIdAsync(chatThreadId))
+            .ReturnsAsync(new ChatThread { ChatThreadId = chatThreadId, ChildId = childId });
+
+        _mockChildrenRepository.Setup(repo => repo.GetParentsByChildIdAsync(childId))
+            .ReturnsAsync(new List<User> { MakeUser(userId) });
+
+        // Act
+        await _chatHub.JoinThread(chatThreadId);
+
+        // Assert
+        _mockGroups.Verify(g => g.AddToGroupAsync("connection-1", $"thread-{chatThreadId}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task JoinThread_TeacherAssociatedWithChild_AddsConnectionToGroup()
+    {
+        // Arrange
+        const int chatThreadId = 5;
+        const int childId = 10;
+        const int userId = 42;
+        SetCallerIdentity(userId, "Teacher");
+
+        _mockChatRepository.Setup(repo => repo.GetChatThreadByIdAsync(chatThreadId))
+            .ReturnsAsync(new ChatThread { ChatThreadId = chatThreadId, ChildId = childId });
+
+        _mockChildrenRepository.Setup(repo => repo.GetTeachersByChildIdAsync(childId))
+            .ReturnsAsync(new List<User> { MakeUser(userId) });
+
+        // Act
+        await _chatHub.JoinThread(chatThreadId);
+
+        // Assert
+        _mockGroups.Verify(g => g.AddToGroupAsync("connection-1", $"thread-{chatThreadId}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task JoinThread_ParentNotAssociatedWithChild_ThrowsHubExceptionAndDoesNotJoinGroup()
+    {
+        // Arrange
+        const int chatThreadId = 5;
+        const int childId = 10;
+        const int userId = 42;
+        SetCallerIdentity(userId, "Parent");
+
+        _mockChatRepository.Setup(repo => repo.GetChatThreadByIdAsync(chatThreadId))
+            .ReturnsAsync(new ChatThread { ChatThreadId = chatThreadId, ChildId = childId });
+
+        // The caller is a Parent, but not one of the parents actually linked to this child.
+        _mockChildrenRepository.Setup(repo => repo.GetParentsByChildIdAsync(childId))
+            .ReturnsAsync(new List<User> { MakeUser(999) });
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HubException>(() => _chatHub.JoinThread(chatThreadId));
+
+        _mockGroups.Verify(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task LeaveThread_ParentNotAssociatedWithChild_ThrowsHubExceptionAndDoesNotLeaveGroup()
+    {
+        // Arrange
+        const int chatThreadId = 5;
+        const int childId = 10;
+        const int userId = 42;
+        SetCallerIdentity(userId, "Parent");
+
+        _mockChatRepository.Setup(repo => repo.GetChatThreadByIdAsync(chatThreadId))
+            .ReturnsAsync(new ChatThread { ChatThreadId = chatThreadId, ChildId = childId });
+
+        _mockChildrenRepository.Setup(repo => repo.GetParentsByChildIdAsync(childId))
+            .ReturnsAsync(new List<User> { MakeUser(999) });
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HubException>(() => _chatHub.LeaveThread(chatThreadId));
+
+        _mockGroups.Verify(g => g.RemoveFromGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/Test/FeedbackChatTests/Service/ChatServiceTests.cs
+++ b/Test/FeedbackChatTests/Service/ChatServiceTests.cs
@@ -1,0 +1,129 @@
+using AutoMapper;
+using FoodplannerModels.Account;
+using FoodplannerModels.FeedbackChat;
+using FoodplannerServices.FeedbackChat;
+using FoodplannerServices.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Test.Service;
+
+public class ChatServiceTests
+{
+    private readonly Mock<IChatRepository> _mockChatRepository;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IChildrenRepository> _mockChildrenRepository;
+    private readonly Mock<IUserRepository> _mockUserRepository;
+    private readonly Mock<IHubContext<ChatHub>> _mockHubContext;
+    private readonly Mock<IHubClients> _mockHubClients;
+    private readonly Mock<IClientProxy> _mockClientProxy;
+    private readonly Mock<ILogger<ChatService>> _mockLogger;
+    private readonly ChatService _chatService;
+
+    public ChatServiceTests()
+    {
+        _mockChatRepository = new Mock<IChatRepository>();
+        _mockMapper = new Mock<IMapper>();
+        _mockChildrenRepository = new Mock<IChildrenRepository>();
+        _mockUserRepository = new Mock<IUserRepository>();
+        _mockHubContext = new Mock<IHubContext<ChatHub>>();
+        _mockHubClients = new Mock<IHubClients>();
+        _mockClientProxy = new Mock<IClientProxy>();
+        _mockLogger = new Mock<ILogger<ChatService>>();
+
+        _mockHubClients.Setup(clients => clients.Group(It.IsAny<string>())).Returns(_mockClientProxy.Object);
+        _mockHubContext.Setup(hub => hub.Clients).Returns(_mockHubClients.Object);
+
+        _chatService = new ChatService(
+            _mockChatRepository.Object,
+            _mockMapper.Object,
+            _mockChildrenRepository.Object,
+            _mockUserRepository.Object,
+            _mockHubContext.Object,
+            _mockLogger.Object
+        );
+    }
+
+    [Fact]
+    public async Task AddMessageAsync_InsertsMessageAndBroadcastsToCorrectGroup()
+    {
+        // Arrange
+        var messageDto = new AddMessageDTO { ChatThreadId = 42, Content = "Hello" };
+        const int userId = 7;
+        var expectedGroupName = $"thread-{messageDto.ChatThreadId}";
+
+        _mockMapper.Setup(m => m.Map<Message>(messageDto))
+            .Returns(new Message { ChatThreadId = messageDto.ChatThreadId, Content = messageDto.Content });
+
+        var broadcastDto = new UserNameFeedbackChatDTO { Content = messageDto.Content, FirstName = "" };
+        _mockMapper.Setup(m => m.Map<UserNameFeedbackChatDTO>(It.IsAny<Message>()))
+            .Returns(broadcastDto);
+
+        _mockUserRepository.Setup(repo => repo.GetByIdAsync(userId))
+            .ReturnsAsync(new User
+            {
+                Id = userId,
+                FirstName = "Alice",
+                LastName = "Smith",
+                Email = "alice@example.com",
+                Password = "hashed",
+                Role = UserRole.Parent,
+                RoleApproved = true
+            });
+
+        // Act
+        var result = await _chatService.AddMessageAsync(messageDto, userId);
+
+        // Assert
+        Assert.True(result);
+
+        _mockChatRepository.Verify(repo => repo.InsertAsync(It.Is<Message>(m =>
+            m.ChatThreadId == messageDto.ChatThreadId &&
+            m.Content == messageDto.Content &&
+            m.UserId == userId)), Times.Once);
+
+        _mockHubClients.Verify(clients => clients.Group(expectedGroupName), Times.Once);
+
+        _mockClientProxy.Verify(proxy => proxy.SendCoreAsync(
+            "ReceiveMessage",
+            It.Is<object[]>(args => args.Length == 1 && args[0] == broadcastDto),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // The broadcast DTO is mutated in place with the sender's name looked up via IUserRepository,
+        // matching the same first_name that GetMessagesAsync's SQL join would have provided.
+        Assert.Equal("Alice", broadcastDto.FirstName);
+    }
+
+    [Fact]
+    public async Task AddMessageAsync_BroadcastThrows_StillReturnsTrueAndInsertsMessage()
+    {
+        // Arrange
+        var messageDto = new AddMessageDTO { ChatThreadId = 42, Content = "Hello" };
+        const int userId = 7;
+
+        _mockMapper.Setup(m => m.Map<Message>(messageDto))
+            .Returns(new Message { ChatThreadId = messageDto.ChatThreadId, Content = messageDto.Content });
+
+        _mockMapper.Setup(m => m.Map<UserNameFeedbackChatDTO>(It.IsAny<Message>()))
+            .Returns(new UserNameFeedbackChatDTO { Content = messageDto.Content, FirstName = "" });
+
+        _mockUserRepository.Setup(repo => repo.GetByIdAsync(userId))
+            .ReturnsAsync((User?)null);
+
+        _mockClientProxy
+            .Setup(proxy => proxy.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Hub is unreachable"));
+
+        // Act
+        var result = await _chatService.AddMessageAsync(messageDto, userId);
+
+        // Assert — the broadcast failure must not propagate or change the outcome of message creation.
+        Assert.True(result);
+
+        _mockChatRepository.Verify(repo => repo.InsertAsync(It.Is<Message>(m =>
+            m.ChatThreadId == messageDto.ChatThreadId &&
+            m.Content == messageDto.Content &&
+            m.UserId == userId)), Times.Once);
+    }
+}

--- a/Test/FeedbackChatTests/Service/ChatServiceTests.cs
+++ b/Test/FeedbackChatTests/Service/ChatServiceTests.cs
@@ -96,6 +96,54 @@ public class ChatServiceTests
     }
 
     [Fact]
+    public async Task AddMessageAsync_BroadcastsMessageWithGeneratedMessageIdAndChatThreadId()
+    {
+        // Arrange
+        var messageDto = new AddMessageDTO { ChatThreadId = 42, Content = "Hello" };
+        const int userId = 7;
+        const int generatedMessageId = 123;
+
+        _mockMapper.Setup(m => m.Map<Message>(messageDto))
+            .Returns(new Message { ChatThreadId = messageDto.ChatThreadId, Content = messageDto.Content });
+
+        // Mirrors ChatRepository.InsertAsync, which now does "RETURNING message_id" and
+        // assigns the generated id back onto the passed-in Message before returning.
+        _mockChatRepository.Setup(repo => repo.InsertAsync(It.IsAny<Message>()))
+            .Callback<Message>(m => m.MessageId = generatedMessageId)
+            .ReturnsAsync(generatedMessageId);
+
+        UserNameFeedbackChatDTO? broadcastDto = null;
+        _mockMapper.Setup(m => m.Map<UserNameFeedbackChatDTO>(It.IsAny<Message>()))
+            .Returns((Message src) =>
+            {
+                broadcastDto = new UserNameFeedbackChatDTO
+                {
+                    MessageId = src.MessageId,
+                    ChatThreadId = src.ChatThreadId,
+                    Content = src.Content,
+                    FirstName = ""
+                };
+                return broadcastDto;
+            });
+
+        _mockUserRepository.Setup(repo => repo.GetByIdAsync(userId))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        await _chatService.AddMessageAsync(messageDto, userId);
+
+        // Assert
+        Assert.NotNull(broadcastDto);
+        Assert.Equal(generatedMessageId, broadcastDto!.MessageId);
+        Assert.Equal(messageDto.ChatThreadId, broadcastDto.ChatThreadId);
+
+        _mockClientProxy.Verify(proxy => proxy.SendCoreAsync(
+            "ReceiveMessage",
+            It.Is<object[]>(args => args.Length == 1 && args[0] == broadcastDto),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task AddMessageAsync_BroadcastThrows_StillReturnsTrueAndInsertsMessage()
     {
         // Arrange
@@ -125,5 +173,36 @@ public class ChatServiceTests
             m.ChatThreadId == messageDto.ChatThreadId &&
             m.Content == messageDto.Content &&
             m.UserId == userId)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMessagesAsync_ReturnsMessagesIncludingMessageIdAndChatThreadId()
+    {
+        // Arrange
+        const int chatThreadId = 42;
+        var storedMessages = new List<Message>
+        {
+            new Message { MessageId = 1, ChatThreadId = chatThreadId, Content = "Hi", UserId = 7 }
+        };
+
+        _mockChatRepository.Setup(repo => repo.GetMessagesByChatThreadIdAsync(chatThreadId))
+            .ReturnsAsync(storedMessages);
+
+        _mockMapper.Setup(m => m.Map<UserNameFeedbackChatDTO>(It.IsAny<Message>()))
+            .Returns((Message src) => new UserNameFeedbackChatDTO
+            {
+                MessageId = src.MessageId,
+                ChatThreadId = src.ChatThreadId,
+                Content = src.Content,
+                FirstName = ""
+            });
+
+        // Act
+        var result = (await _chatService.GetMessagesAsync(chatThreadId)).ToList();
+
+        // Assert
+        var dto = Assert.Single(result);
+        Assert.Equal(1, dto.MessageId);
+        Assert.Equal(chatThreadId, dto.ChatThreadId);
     }
 }

--- a/docs/feedbackchat-signalr-report.md
+++ b/docs/feedbackchat-signalr-report.md
@@ -18,18 +18,32 @@ keeping the existing SQL persistence as the single source of truth.
 
 ## 2. Files changed
 
-**New files:**
+**New files (initial feature):**
 - `FoodplannerServices/Hubs/ChatHub.cs`
 - `Test/FeedbackChatTests/Service/ChatServiceTests.cs`
 - `docs/SIGNALR_TESTING.md` *(superseded by this report; kept for reference)*
 
-**Modified files:**
+**Modified files (initial feature):**
 - `FoodplannerApi/Program.cs`
 - `FoodplannerServices/FeedbackChat/ChatService.cs`
 - `FoodplannerServices/FoodplannerServices.csproj`
 
 **Unchanged (confirmed):** `FoodplannerModels/FeedbackChat/IChatService.cs` — the
 interface signature for `AddMessageAsync` did not need to change.
+
+**Follow-up fixes — new files:**
+- `Test/FeedbackChatTests/Hub/ChatHubTests.cs` (object-level authorization)
+- `Test/FeedbackChatTests/ChatProfileTests.cs` (real-AutoMapper convention check)
+
+**Follow-up fixes — modified files:**
+- `FoodplannerServices/Hubs/ChatHub.cs` (§3.4 — thread-ownership check)
+- `FoodplannerModels/FeedbackChat/IChatRepository.cs` (§3.4 — exposed
+  `GetChatThreadByIdAsync`, no new query)
+- `FoodplannerModels/FeedbackChat/UserNameFeedbackChatDTO.cs` (§3.5 —
+  `MessageId`/`ChatThreadId`)
+- `FoodplannerDataAccessSql/FeedbackChat/ChatRepository.cs` (§3.5 —
+  `InsertAsync` now returns the generated id via `RETURNING message_id`)
+- `Test/FeedbackChatTests/Service/ChatServiceTests.cs` (§3.6 — new tests)
 
 ---
 
@@ -118,7 +132,63 @@ broadcast outcome):
    succeeded. A broadcast failure never turns a successful message creation
    into an HTTP error for the caller.
 
-### 3.4 Tests
+### 3.4 Object-level authorization on `JoinThread`/`LeaveThread`
+
+**Follow-up fix (code review):** class-level `[Authorize(Roles = "Parent,
+Teacher")]` alone let any approved Parent or Teacher join *any* chat
+thread's group, regardless of whether they were actually associated with
+the child that thread belongs to. Unlike the REST endpoints (which were
+never meant to be production-hardened), the hub now enforces this:
+
+`ChatHub` takes `IChatRepository` and `IChildrenRepository` via constructor
+injection (both already registered in DI, so no `Program.cs` change was
+needed). Both `JoinThread` and `LeaveThread` call a shared private helper,
+`EnsureCallerIsAuthorizedForThreadAsync`, before touching the group:
+
+1. Look up the `ChatThread` via `IChatRepository.GetChatThreadByIdAsync`
+   (already existed on the concrete `ChatRepository`, just not previously
+   exposed on `IChatRepository` — added to the interface rather than
+   duplicating the query) to get its `ChildId`.
+2. Read the caller's id from the `ClaimTypes.NameIdentifier` claim and role
+   from `Context.User.IsInRole(...)` — the same claim types
+   `AuthService`/`Program.cs` already use for REST auth
+   (`ClaimTypes.NameIdentifier` for id, `ClaimTypes.Role` as the configured
+   `RoleClaimType`).
+3. If the caller is a Parent, check their id is among
+   `IChildrenRepository.GetParentsByChildIdAsync(childId)`. If a Teacher,
+   check `GetTeachersByChildIdAsync(childId)` instead.
+4. If the check fails, the connection is **not** added to (or removed from)
+   the group, and a `HubException("Not authorized for this chat thread")` is
+   thrown, so the client sees a clear error instead of a silent no-op.
+
+### 3.5 `MessageId`/`ChatThreadId` on the broadcast payload (deduplication)
+
+**Follow-up fix (code review):** since a sender is themselves a member of
+their own chat thread's SignalR group, they receive their own message back
+via `ReceiveMessage`. Without a stable id, the frontend couldn't tell that
+apart from a genuinely new message, so it couldn't deduplicate an
+optimistically-rendered message against the one echoed back over the socket.
+
+- `UserNameFeedbackChatDTO` (used by both `GetMessagesAsync` and the
+  broadcast — same DTO, so history and live messages are now consistent)
+  gained `MessageId` and `ChatThreadId` int properties. `Message` already
+  has both fields under the exact same names, so AutoMapper's existing
+  `CreateMap<Message, UserNameFeedbackChatDTO>()` picks them up by
+  convention with no `.ForMember()` needed — confirmed with a dedicated
+  test using a real `MapperConfiguration` (not a mocked `IMapper`), see
+  below.
+- This exposed a latent bug: `ChatRepository.InsertAsync` ran a plain
+  `INSERT` via Dapper's `ExecuteAsync`, which does **not** populate
+  auto-generated ids back onto the passed-in object — `message.MessageId`
+  stayed `0` after every insert. Fixed by adding `RETURNING message_id`
+  (same pattern already used in `AddChatThreadIdByChildIdAsync`) and using
+  `ExecuteScalarAsync<int>` to read it back, assigning it onto
+  `message.MessageId` before returning. Since `ChatService.AddMessageAsync`
+  maps the broadcast DTO from that same `Message` object *after*
+  `InsertAsync` returns, the correct id now flows through automatically —
+  no `ChatService.cs` change was needed for this part.
+
+### 3.6 Tests
 
 `Test/FeedbackChatTests/Service/ChatServiceTests.cs`, following the existing
 Moq/xUnit conventions used elsewhere in the project, mocks
@@ -132,9 +202,32 @@ Moq/xUnit conventions used elsewhere in the project, mocks
 - If `SendAsync` throws, `AddMessageAsync` still returns `true` and the
   insert is still verified to have happened — a broadcast failure does not
   propagate or change the return value.
+- The broadcast DTO carries the `MessageId` generated by (a mocked)
+  `InsertAsync` and the correct `ChatThreadId`.
+- `GetMessagesAsync`'s mapped results include `MessageId`/`ChatThreadId`.
 
-**Result:** `dotnet build` — 0 errors (2 pre-existing, unrelated warnings).
-`dotnet test` — all tests passing, nothing skipped.
+`Test/FeedbackChatTests/ChatProfileTests.cs` is a new, deliberately
+non-mocked test: it builds a real `MapperConfiguration` with `ChatProfile`
+and asserts `Map<UserNameFeedbackChatDTO>(message)` actually carries
+`MessageId`/`ChatThreadId` through — proving AutoMapper's convention-based
+mapping works, which a mocked `IMapper` test could not prove.
+
+`Test/FeedbackChatTests/Hub/ChatHubTests.cs` is a new test file for
+`ChatHub` (SignalR's `Hub.Context`/`Hub.Groups`/`Hub.Clients` are public
+settable properties specifically to support this kind of unit testing
+without a live connection). Covers:
+
+- `JoinThread` succeeds (adds to the group) for a Parent actually linked to
+  the thread's child, and separately for a Teacher actually linked to it.
+- `JoinThread` throws `HubException` and does **not** add the connection to
+  the group when the caller (Parent or Teacher) is not associated with the
+  thread's child.
+- `LeaveThread` applies the same check and also throws without removing
+  the connection from the group when unauthorized.
+
+**Result:** `dotnet build` — 0 errors. `dotnet test` — 167/167 passing,
+nothing skipped (160 before this follow-up + 7 new tests: 4 in
+`ChatHubTests`, 2 in `ChatServiceTests`, 1 in `ChatProfileTests`).
 
 ---
 
@@ -151,13 +244,17 @@ Moq/xUnit conventions used elsewhere in the project, mocks
   everything buildable without changing the intended dependency injection
   pattern.
 - **No new database migration** — no schema changes were needed.
-- **Existing authorization gap intentionally preserved:** a chat thread is
-  not validated against the caller's actual association with the child —
-  any approved Parent/Teacher can join/query any `chatThreadId`. This
-  matches `FeedbackChatController`'s current REST behavior and was kept
-  consistent for the hub rather than silently tightened, to avoid scope
-  creep beyond issue #230. Worth a follow-up issue if stricter enforcement
-  is wanted.
+- **Object-level authorization gap — fixed (see §3.4):** joining or leaving
+  a chat thread's SignalR group now verifies the caller is actually a
+  parent or teacher associated with that thread's child, via
+  `IChildrenRepository`. This intentionally only covers the hub, per the
+  maintainer's review feedback — the REST endpoints
+  (`FeedbackChatController`) were explicitly out of scope for this
+  follow-up and still don't validate thread ownership; that would be a
+  separate change if wanted.
+- **Missing `MessageId`/`ChatThreadId` on the broadcast DTO — fixed (see
+  §3.5):** the frontend can now deduplicate a message it rendered
+  optimistically against the copy echoed back over the socket.
 - **No delivery retry/guarantee** if a client is briefly disconnected when a
   broadcast fires — out of scope for this issue.
 - **Frontend (Flutter) integration is not part of this change** — this is a
@@ -250,6 +347,30 @@ Set-Clipboard -Value ('{"type":1,"target":"JoinThread","arguments":[<chatThreadI
 Paste into Postman and **Send**. There's no response expected for this call
 (it's a `void`/`Task`-returning hub method) — no news is good news here.
 
+`JoinThread` now checks that you're actually a Parent/Teacher associated
+with the given thread's child (§3.4). SignalR only sends a completion
+message back for invocations that include an `invocationId` — the
+fire-and-forget payload above (no `invocationId`) will just silently not
+join the group if unauthorized, with nothing visible in Postman. To
+actually see the error, include an `invocationId`:
+
+```powershell
+Set-Clipboard -Value ('{"type":1,"invocationId":"1","target":"JoinThread","arguments":[<chatThreadId>]}' + [char]0x1e)
+```
+
+If you use a `chatThreadId` that belongs to a different child than the one
+your logged-in user is linked to, you'll get back:
+
+```json
+{"type":3,"invocationId":"1","error":"Not authorized for this chat thread"}
+```
+
+`HubException` messages (unlike other exception types) are always sent to
+the client verbatim, regardless of `EnableDetailedErrors` — that's why
+`ChatHub` throws `HubException` specifically rather than a generic
+exception. Either way — with or without an `invocationId` — an unauthorized
+call never adds the connection to the thread's group.
+
 ### Step 5 — Trigger a message and watch it arrive live
 
 From Swagger (or a separate Postman HTTP request), with a valid
@@ -266,11 +387,13 @@ Content-Type: application/json
 The WebSocket tab from Step 4 should immediately receive:
 
 ```json
-{"type":1,"target":"ReceiveMessage","arguments":[{"content":"Test message","firstName":"Test","date":"2026-07-22T22:49:28.8458292+02:00","archived":false,"isEdited":false}]}
+{"type":1,"target":"ReceiveMessage","arguments":[{"messageId":57,"chatThreadId":5,"content":"Test message","firstName":"Test","date":"2026-07-22T22:49:28.8458292+02:00","archived":false,"isEdited":false}]}
 ```
 
-No polling, no reconnect, no manual refresh needed — and `firstName` is
-populated, confirming the sender-name fix is working.
+No polling, no reconnect, no manual refresh needed — `firstName` is
+populated (confirming the sender-name fix), and `messageId`/`chatThreadId`
+are now present so a client that already rendered this message
+optimistically can recognize it and skip rendering a duplicate.
 
 ### Troubleshooting
 
@@ -280,20 +403,91 @@ populated, confirming the sender-name fix is working.
 | `401` on WebSocket connect | `RoleApproved` is `false`, or token expired/malformed |
 | Handshake sent but connection drops / `"Handshake was canceled"` | The `0x1e` terminator is missing — you likely typed the message directly instead of pasting the clipboard result; re-run the `Set-Clipboard` command and paste again |
 | Connected + handshake OK, but no `ReceiveMessage` ever arrives | `JoinThread` wasn't sent, or its `chatThreadId` doesn't match the one used in `AddMessage`; also check server logs — a broadcast failure is logged but silently swallowed, so `AddMessage` would still report success with nothing arriving |
+| `JoinThread`/`LeaveThread` completion has `"error":"Not authorized for this chat thread"` (only visible if you sent an `invocationId`) | The logged-in user is a Parent/Teacher, but not one associated with that `chatThreadId`'s child — use a `chatThreadId` for a child your test user is actually linked to (§3.4) |
 | Connection drops shortly after connecting | JWT expired — get a fresh token via Login and reconnect |
 
 ---
 
 ## 6. Verified result
 
-End-to-end tested manually on 2026-07-22 via the steps above. Confirmed
-received payload:
+### 6.1 Initial feature — 2026-07-22
+
+End-to-end tested manually via the steps above (predating the object-level
+authorization and `MessageId`/`ChatThreadId` follow-up fixes). Confirmed
+received payload at that time:
 
 ```json
 {"type":1,"target":"ReceiveMessage","arguments":[{"content":"Test message","firstName":"Test","date":"2026-07-22T22:49:28.8458292+02:00","archived":false,"isEdited":false}]}
 ```
 
-This confirms: the hub authenticates correctly over WebSocket, group
+This confirmed the hub authenticates correctly over WebSocket, group
 membership via `JoinThread` works, the broadcast fires immediately after
 `AddMessage` persists the message, and the sender's name is correctly
-populated (the second follow-up fix).
+populated.
+
+### 6.2 Follow-up fixes (review feedback) — 2026-08-04
+
+The two follow-up fixes in §3.4/§3.5 were re-verified manually end-to-end
+via Postman, on top of the automated tests in §3.6 (`dotnet test`,
+167/167 passing), using two separate Parent users each with their own
+child and chat thread.
+
+**Object-level authorization on `JoinThread` (§3.4):**
+
+- **Positive case** — joining a thread the connected user is actually
+  associated with succeeds:
+  ```json
+  {"type":1,"invocationId":"1","target":"JoinThread","arguments":[1]}
+  ```
+  ```json
+  {"type":3,"invocationId":"1","result":null}
+  ```
+- **Negative case** — the same connection then attempted to join a second
+  thread (`chatThreadId: 2`) belonging to a different, unrelated Parent
+  user. The server-side log confirms the request reached and was rejected
+  by the new authorization check, not by an unrelated error:
+  ```
+  fail: Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher[8]
+        Failed to invoke hub method 'JoinThread'.
+        Microsoft.AspNetCore.SignalR.HubException: Not authorized for this chat thread
+           at FoodplannerServices.Hubs.ChatHub.EnsureCallerIsAuthorizedForThreadAsync(Int32 chatThreadId) ...
+           at FoodplannerServices.Hubs.ChatHub.JoinThread(Int32 chatThreadId) ...
+  ```
+  (The Postman client itself only surfaced a generic "An unexpected error
+  occurred invoking 'JoinThread' on the server" message rather than the
+  `HubException`'s own text — a client-side display detail, not a defect
+  in the authorization check itself, which the server log confirms ran
+  and rejected the call as intended.)
+- **No unauthorized data leak** — a message was then posted to thread `2`
+  (`POST api/FeedbackChat/AddMessage`). The rejected connection, never
+  having been added to `thread-2`'s SignalR group, received nothing —
+  confirming the authorization check has a real effect on message
+  delivery, not just on the join call's return value.
+
+**`MessageId`/`ChatThreadId` on the broadcast DTO (§3.5):**
+
+A message posted to the thread the connection *was* validly joined to
+(`chatThreadId: 1`) arrived with both fields populated with real,
+non-zero values:
+
+```json
+{"type":1,"target":"ReceiveMessage","arguments":[{"messageId":6,"chatThreadId":1,"content":"test 1","firstName":"parent2","date":"2026-08-04T18:19:58.0912489+02:00","archived":false,"isEdited":false}]}
+```
+
+`messageId: 6` confirms the `RETURNING message_id` fix in
+`ChatRepository.InsertAsync` (§3.5) actually flows through to the broadcast
+— not just that the DTO has the field, but that it's populated with the
+real generated id rather than `0`.
+
+### 6.3 Summary
+
+| Check | Result |
+|---|---|
+| `JoinThread` succeeds for a thread the caller owns | ✅ confirmed |
+| `JoinThread` rejects a thread the caller does not own | ✅ confirmed (server log) |
+| Rejected caller receives no messages from that thread | ✅ confirmed (no leak) |
+| Broadcast `messageId` is a real, non-zero id | ✅ confirmed (`6`) |
+| Broadcast `chatThreadId` is correct | ✅ confirmed (`1`) |
+
+Both follow-up fixes are confirmed working end-to-end, not only at the
+level of mocked unit tests.

--- a/docs/feedbackchat-signalr-report.md
+++ b/docs/feedbackchat-signalr-report.md
@@ -1,0 +1,299 @@
+# Real-Time Messaging for FeedbackChat via SignalR — Implementation & Testing Report
+
+**Repository:** `aau-giraf/foodplanner-api`
+**Issue:** [#230 — Change message database to use SignalR or something of the like](https://github.com/aau-giraf/foodplanner-api/issues/230)
+**Branch:** `feature/signalr-realtime-chat`
+
+---
+
+## 1. Summary
+
+The `FeedbackChat` module previously required clients to poll
+`GET api/FeedbackChat/getmessage/{chatThreadId}` to see new messages between
+a Parent and a Teacher discussing a specific child. This feature adds a
+SignalR hub so connected clients receive new messages instantly, while
+keeping the existing SQL persistence as the single source of truth.
+
+---
+
+## 2. Files changed
+
+**New files:**
+- `FoodplannerServices/Hubs/ChatHub.cs`
+- `Test/FeedbackChatTests/Service/ChatServiceTests.cs`
+- `docs/SIGNALR_TESTING.md` *(superseded by this report; kept for reference)*
+
+**Modified files:**
+- `FoodplannerApi/Program.cs`
+- `FoodplannerServices/FeedbackChat/ChatService.cs`
+- `FoodplannerServices/FoodplannerServices.csproj`
+
+**Unchanged (confirmed):** `FoodplannerModels/FeedbackChat/IChatService.cs` — the
+interface signature for `AddMessageAsync` did not need to change.
+
+---
+
+## 3. Implementation
+
+### 3.1 `ChatHub`
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace FoodplannerServices.Hubs;
+
+[Authorize(Roles = "Parent, Teacher")]
+public class ChatHub : Hub
+{
+    public async Task JoinThread(int chatThreadId)
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"thread-{chatThreadId}");
+    }
+
+    public async Task LeaveThread(int chatThreadId)
+    {
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"thread-{chatThreadId}");
+    }
+}
+```
+
+Each connection explicitly joins a group named `thread-{chatThreadId}` after
+connecting; nothing joins automatically. Groups are server-side bookkeeping
+only (no persistence) and a connection is dropped from all groups on
+disconnect.
+
+### 3.2 JWT authentication over WebSocket
+
+Browsers/WebSocket clients can't set custom headers on the handshake, so the
+token can't ride in the `Authorization` header the way REST calls do.
+`Program.cs` extends the *existing* `AddJwtBearer` events with a single
+`OnMessageReceived` handler that reads `access_token` from the query string
+— but only for requests to `/hubs/chat`:
+
+```csharp
+OnMessageReceived = context =>
+{
+    var accessToken = context.Request.Query["access_token"];
+
+    if (!string.IsNullOrEmpty(accessToken) &&
+        context.HttpContext.Request.Path.StartsWithSegments("/hubs/chat"))
+    {
+        context.Token = accessToken;
+    }
+
+    return Task.CompletedTask;
+},
+```
+
+For every other path (all REST controllers), this branch is skipped and the
+framework falls back to normal `Authorization: Bearer ...` header parsing —
+**no change to how REST endpoints authenticate.** The existing
+`RoleApproved` claim check in `OnTokenValidated` runs identically for both
+paths.
+
+SignalR registration and hub mapping:
+
+```csharp
+builder.Services.AddSignalR();
+// ...
+app.MapHub<ChatHub>("/hubs/chat");
+```
+
+### 3.3 Broadcasting on message creation
+
+`ChatService` now takes `IHubContext<ChatHub>` via constructor injection.
+Inside `AddMessageAsync`, immediately after
+`await _chatRepository.InsertAsync(message)` succeeds (still the first and
+unconditional side effect — persistence is never rolled back based on the
+broadcast outcome):
+
+1. The sender's first name is looked up (same approach `GetMessagesAsync`
+   already uses via its SQL join) and attached to the outgoing DTO.
+2. The message is broadcast to `Clients.Group($"thread-{message.ChatThreadId}")`
+   via the `"ReceiveMessage"` event.
+3. The whole broadcast step (name lookup + `SendAsync`) is wrapped in a
+   try/catch. On failure, the error is logged and swallowed —
+   `AddMessageAsync` still returns `true` as long as the SQL insert
+   succeeded. A broadcast failure never turns a successful message creation
+   into an HTTP error for the caller.
+
+### 3.4 Tests
+
+`Test/FeedbackChatTests/Service/ChatServiceTests.cs`, following the existing
+Moq/xUnit conventions used elsewhere in the project, mocks
+`IHubContext<ChatHub>` → `IHubClients` → `IClientProxy` and covers:
+
+- `InsertAsync` is called with the correct `ChatThreadId`, `Content`, and
+  `UserId`.
+- `SendAsync("ReceiveMessage", ...)` is called on the correct group
+  (`thread-{chatThreadId}`).
+- The broadcast DTO includes a non-empty `FirstName`.
+- If `SendAsync` throws, `AddMessageAsync` still returns `true` and the
+  insert is still verified to have happened — a broadcast failure does not
+  propagate or change the return value.
+
+**Result:** `dotnet build` — 0 errors (2 pre-existing, unrelated warnings).
+`dotnet test` — all tests passing, nothing skipped.
+
+---
+
+## 4. Design decisions & known limitations
+
+- **Why `ChatHub` lives in `FoodplannerServices`, not `FoodplannerApi`:**
+  `ChatService` (in `FoodplannerServices`) needs to inject
+  `IHubContext<ChatHub>`. `FoodplannerApi` already has a one-directional
+  `ProjectReference` to `FoodplannerServices`; putting the hub in
+  `FoodplannerApi` would require a circular project reference, which .NET's
+  build system rejects. Moving the hub to `FoodplannerServices` (with a new
+  `FrameworkReference` to `Microsoft.AspNetCore.App` so `Hub`/
+  `IHubContext`/`[Authorize]` are available in that class library) keeps
+  everything buildable without changing the intended dependency injection
+  pattern.
+- **No new database migration** — no schema changes were needed.
+- **Existing authorization gap intentionally preserved:** a chat thread is
+  not validated against the caller's actual association with the child —
+  any approved Parent/Teacher can join/query any `chatThreadId`. This
+  matches `FeedbackChatController`'s current REST behavior and was kept
+  consistent for the hub rather than silently tightened, to avoid scope
+  creep beyond issue #230. Worth a follow-up issue if stricter enforcement
+  is wanted.
+- **No delivery retry/guarantee** if a client is briefly disconnected when a
+  broadcast fires — out of scope for this issue.
+- **Frontend (Flutter) integration is not part of this change** — this is a
+  backend-only feature, verified manually via the Postman walkthrough below.
+- A pre-existing, unused `Microsoft.AspNetCore.SignalR` 1.1.0
+  `PackageReference` in `FoodplannerApi.csproj` (predating shared-framework
+  SignalR) was left untouched, since removing it wasn't required for this
+  change.
+
+---
+
+## 5. Manual testing guide (Postman)
+
+This section walks through verifying, by hand, that `ChatHub` broadcasts new
+messages live to everyone connected to a chat thread. It assumes the API is
+running locally (adjust `localhost:8080` to your actual `BACKEND_PORT`).
+
+### Step 1 — Get a JWT for a Parent or Teacher user
+
+The hub requires `[Authorize(Roles = "Parent, Teacher")]` **and**
+`RoleApproved = true` on the token — the same requirements as the REST
+`FeedbackChatController`.
+
+**Quickest path if you don't have a test user yet** (all via Swagger):
+
+1. `GET api/Users/GetBearerTest` → returns an `Admin` token. Useful only to
+   authorize the next step — an `Admin` token will **not** pass the hub's
+   role check itself.
+2. `POST api/Users/Create` with `{"firstName": "...", "lastName": "...",
+   "email": "...", "password": "...", "role": "Parent"}` → returns the new
+   user's numeric `id`.
+3. `PUT api/Admin/updaterole/{id}` with `Authorization: Bearer <admin token>`
+   and body `{"role_approved": true}` — without this, the user's JWT will
+   carry `RoleApproved = false` and every authenticated call (REST or hub)
+   is rejected.
+4. `POST api/Users/Login` with `{"email": "...", "password": "..."}` →
+   returns the raw JWT for this Parent/Teacher user. **This is the token you
+   use for the WebSocket connection below** — no `Bearer ` prefix.
+
+### Step 2 — Open a WebSocket connection in Postman
+
+1. Postman → **New → WebSocket Request**.
+2. URL, with the token as a query parameter (the hub only accepts the token
+   via query string, since WebSocket clients can't set custom headers on
+   the handshake):
+   ```
+   ws://localhost:8080/hubs/chat?access_token=<token from Step 1>
+   ```
+3. Click **Connect**. A successful connection means the JWT and role check
+   passed. A `403` means the token's role isn't `Parent`/`Teacher` (e.g. you
+   used the `Admin` token from Step 1.1 by mistake — go back and use the
+   Login token instead). A `401` usually means `RoleApproved` is still
+   `false`, or the token is malformed.
+
+   *(Optional: repeat this in a second Postman WebSocket tab with another
+   valid token, to simulate two connected clients receiving the same
+   broadcast.)*
+
+### Step 3 — Send the SignalR protocol handshake
+
+SignalR requires a handshake message as the **first** message on the
+socket, before invoking any hub method — a JSON object naming the protocol,
+terminated by the ASCII **Record Separator** character (`0x1E`), which is
+invisible and can't just be typed.
+
+The most reliable way to get the exact bytes into Postman's message field —
+**run this in a terminal, not in Postman itself** — then switch to Postman
+and paste (Ctrl+V) the result into the message box:
+
+```powershell
+Set-Clipboard -Value ('{"protocol":"json","version":1}' + [char]0x1e)
+```
+
+(macOS/Linux equivalent: `printf '{"protocol":"json","version":1}\x1e' | pbcopy`,
+or from any browser console: `copy('{"protocol":"json","version":1}' + String.fromCharCode(0x1e))`.)
+
+Paste into Postman's message field and click **Send**. A successful
+handshake returns `{}` (also `0x1e`-terminated) from the server. You may
+also see occasional `{"type":6}` messages appear on their own — these are
+SignalR keep-alive pings and can be ignored.
+
+### Step 4 — Join a chat thread
+
+Same trick, different payload — run in the terminal:
+
+```powershell
+Set-Clipboard -Value ('{"type":1,"target":"JoinThread","arguments":[<chatThreadId>]}' + [char]0x1e)
+```
+
+Paste into Postman and **Send**. There's no response expected for this call
+(it's a `void`/`Task`-returning hub method) — no news is good news here.
+
+### Step 5 — Trigger a message and watch it arrive live
+
+From Swagger (or a separate Postman HTTP request), with a valid
+Parent/Teacher token:
+
+```
+POST api/FeedbackChat/AddMessage
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ "chatThreadId": <same id as Step 4>, "content": "Test message" }
+```
+
+The WebSocket tab from Step 4 should immediately receive:
+
+```json
+{"type":1,"target":"ReceiveMessage","arguments":[{"content":"Test message","firstName":"Test","date":"2026-07-22T22:49:28.8458292+02:00","archived":false,"isEdited":false}]}
+```
+
+No polling, no reconnect, no manual refresh needed — and `firstName` is
+populated, confirming the sender-name fix is working.
+
+### Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `403` on WebSocket connect | Token's role isn't `Parent`/`Teacher` (e.g. used the `Admin` token) |
+| `401` on WebSocket connect | `RoleApproved` is `false`, or token expired/malformed |
+| Handshake sent but connection drops / `"Handshake was canceled"` | The `0x1e` terminator is missing — you likely typed the message directly instead of pasting the clipboard result; re-run the `Set-Clipboard` command and paste again |
+| Connected + handshake OK, but no `ReceiveMessage` ever arrives | `JoinThread` wasn't sent, or its `chatThreadId` doesn't match the one used in `AddMessage`; also check server logs — a broadcast failure is logged but silently swallowed, so `AddMessage` would still report success with nothing arriving |
+| Connection drops shortly after connecting | JWT expired — get a fresh token via Login and reconnect |
+
+---
+
+## 6. Verified result
+
+End-to-end tested manually on 2026-07-22 via the steps above. Confirmed
+received payload:
+
+```json
+{"type":1,"target":"ReceiveMessage","arguments":[{"content":"Test message","firstName":"Test","date":"2026-07-22T22:49:28.8458292+02:00","archived":false,"isEdited":false}]}
+```
+
+This confirms: the hub authenticates correctly over WebSocket, group
+membership via `JoinThread` works, the broadcast fires immediately after
+`AddMessage` persists the message, and the sender's name is correctly
+populated (the second follow-up fix).


### PR DESCRIPTION
Implements real-time messaging for the FeedbackChat module using SignalR.
Clients connected to a chat thread now receive new messages live via a
WebSocket push, instead of polling GET api/FeedbackChat/getmessage/{chatThreadId}.

- New ChatHub (FoodplannerServices/Hubs/ChatHub.cs) with JoinThread/LeaveThread,
  authorized for Parent/Teacher roles, matching FeedbackChatController.
- JWT auth extended to accept the token via query string, scoped strictly
  to /hubs/chat — no change to REST endpoint authentication.
- ChatService.AddMessageAsync broadcasts the new message (with sender name)
  after persisting it. SQL remains the source of truth; broadcast failures
  are logged and swallowed so they never fail message creation.
- Unit tests added covering the broadcast, correct group targeting, and
  broadcast-failure resilience.
- Manual testing guide included for verifying the feature via Postman's
  WebSocket client.

Note: ChatHub lives in FoodplannerServices rather than FoodplannerApi to
avoid a circular project reference (FoodplannerApi already references
FoodplannerServices).

**Full implementation & testing report: `docs/feedbackchat-signalr-report.md`**